### PR TITLE
Add missing includes in mainwindow.cpp

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8,6 +8,8 @@
 #include <QHeaderView>
 #include <QApplication>
 #include <QProgressBar>
+#include <algorithm>
+#include <QSet>
 #include "logger.h"
 
 MainWindow::MainWindow(QWidget *parent)


### PR DESCRIPTION
## Summary
- include `<algorithm>` and `<QSet>` in `mainwindow.cpp`

## Testing
- `qmake DownloadAssistant.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858e63b49e083319a578713186c8b11