### PR TITLE
Add automatic SMB URL normalization

### DIFF
--- a/DownloadAssistant.pro
+++ b/DownloadAssistant.pro
@@ -24,7 +24,8 @@ SOURCES += \
     src/smbworker.cpp \
     src/logger.cpp \
     src/remote_smbfile_dialog.cpp \
-    src/tasktablewidget.cpp
+    src/tasktablewidget.cpp \
+    src/smbutils.cpp
 
 HEADERS += \
     src/mainwindow.h \
@@ -34,7 +35,8 @@ HEADERS += \
     src/smbworker.h \
     src/logger.h \
     src/remote_smbfile_dialog.h \
-    src/tasktablewidget.h
+    src/tasktablewidget.h \
+    src/smbutils.h
 
 FORMS += \
     src/mainwindow.ui

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -19,6 +19,7 @@
 #include <QPushButton>
 #include <QTableWidgetItem>
 #include <QHeaderView>
+#include "smbutils.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)
@@ -131,7 +132,7 @@ void MainWindow::setupConnections()
 
 void MainWindow::onConnectClicked()
 {
-    QString url = ui->urlEdit->text().trimmed();
+    QString url = normalizeSmbUrl(ui->urlEdit->text());
     if (url.isEmpty()) {
         QMessageBox::warning(this, tr("警告"), tr("请输入 SMB 地址"));
         return;
@@ -369,6 +370,7 @@ QString MainWindow::formatBytes(qint64 bytes) const
 
 void MainWindow::fetchSmbFileList(const QString &url)
 {
+    QString normalizedUrl = normalizeSmbUrl(url);
     ui->remoteFileTable->setRowCount(0);
 
     struct smb2_context *smb2 = smb2_init_context();
@@ -377,7 +379,7 @@ void MainWindow::fetchSmbFileList(const QString &url)
         return;
     }
 
-    struct smb2_url *smburl = smb2_parse_url(smb2, url.toUtf8().constData());
+    struct smb2_url *smburl = smb2_parse_url(smb2, normalizedUrl.toUtf8().constData());
     if (!smburl) {
         showError(tr("SMB URL 解析失败: %1").arg(QString::fromUtf8(smb2_get_error(smb2))));
         smb2_destroy_context(smb2);

--- a/src/remote_smbfile_dialog.cpp
+++ b/src/remote_smbfile_dialog.cpp
@@ -5,6 +5,7 @@
 #include <QInputDialog>
 #include <QDebug>
 #include <QApplication>
+#include "smbutils.h"
 extern "C" {
 #include <smb2/libsmb2.h>
 #include <smb2/smb2.h>
@@ -61,7 +62,7 @@ QStringList RemoteSmbFileDialog::selectedFiles() const
 
 void RemoteSmbFileDialog::onFetchClicked()
 {
-    QString url = urlEdit->text().trimmed();
+    QString url = normalizeSmbUrl(urlEdit->text());
     if (url.isEmpty()) {
         QMessageBox::warning(this, tr("提示"), tr("请输入 SMB 目录地址"));
         return;
@@ -71,7 +72,8 @@ void RemoteSmbFileDialog::onFetchClicked()
 
 void RemoteSmbFileDialog::fetchSmbFileList(const QString &url)
 {
-    m_currentUrl = url;
+    QString normalizedUrl = normalizeSmbUrl(url);
+    m_currentUrl = normalizedUrl;
     m_fileList.clear();
     fileListWidget->clear();
     statusLabel->setText(tr("正在获取文件列表..."));
@@ -85,7 +87,7 @@ void RemoteSmbFileDialog::fetchSmbFileList(const QString &url)
     }
 
     // 解析 URL
-    struct smb2_url *smburl = smb2_parse_url(smb2, url.toUtf8().constData());
+    struct smb2_url *smburl = smb2_parse_url(smb2, normalizedUrl.toUtf8().constData());
     if (!smburl) {
         statusLabel->setText(tr("SMB URL 解析失败: %1").arg(QString::fromUtf8(smb2_get_error(smb2))));
         smb2_destroy_context(smb2);

--- a/src/smbutils.cpp
+++ b/src/smbutils.cpp
@@ -1,0 +1,27 @@
+#include "smbutils.h"
+
+QString normalizeSmbUrl(const QString &input)
+{
+    QString url = input;
+    url.remove('\r');
+    url.remove('\n');
+    url = url.trimmed();
+
+    // Replace backslashes with forward slashes for UNC style paths
+    url.replace('\\', "/");
+
+    // If URL already starts with smb:// or smb2://, just return after replacement
+    if (url.startsWith("smb://", Qt::CaseInsensitive) ||
+        url.startsWith("smb2://", Qt::CaseInsensitive)) {
+        return url;
+    }
+
+    // Remove leading slashes if any
+    while (url.startsWith('/')) {
+        url.remove(0, 1);
+    }
+
+    // Prepend smb:// scheme
+    url.prepend("smb://");
+    return url;
+}

--- a/src/smbutils.h
+++ b/src/smbutils.h
@@ -1,0 +1,8 @@
+#ifndef SMBUTILS_H
+#define SMBUTILS_H
+
+#include <QString>
+
+QString normalizeSmbUrl(const QString &input);
+
+#endif // SMBUTILS_H


### PR DESCRIPTION
## Summary
- add `smbutils` helper to normalize SMB paths
- integrate SMB path normalization in main window and remote file dialog
- update project file with new sources

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685a44821cd88331a6142356dba94d0f