### PR TITLE
Improve MainWindow logging

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -69,6 +69,7 @@ private:
     void onRemoveClicked();
     void onAllTasksCompleted();
     void showInfo(const QString &message);
+    void showWarning(const QString &message);
     void showError(const QString &message);
     QString formatBytes(qint64 bytes) const;
     void fetchSmbFileList(const QString &url);


### PR DESCRIPTION
## Summary
- add `showWarning` helper
- log info messages in `showInfo`
- record UI actions and task events

## Testing
- `qmake DownloadAssistant.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5c0bf5ac8331a5f63282c9bb975e