### PR TITLE
Fix table columns and refresh controls

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -246,7 +246,7 @@ void MainWindow::onTaskStarted(const QString &taskId)
 {
     DownloadTask *task = m_downloadManager->getTask(taskId);
     if (task) {
-        // ui->taskTable->updateTask(task); // 已注释
+        ui->taskTable->updateTask(task);
         LOG_INFO(QString("任务开始 - ID: %1").arg(taskId));
     }
 }
@@ -255,7 +255,7 @@ void MainWindow::onTaskPaused(const QString &taskId)
 {
     DownloadTask *task = m_downloadManager->getTask(taskId);
     if (task) {
-        // ui->taskTable->updateTask(task); // 已注释
+        ui->taskTable->updateTask(task);
         LOG_INFO(QString("任务暂停 - ID: %1").arg(taskId));
     }
 }
@@ -264,7 +264,7 @@ void MainWindow::onTaskResumed(const QString &taskId)
 {
     DownloadTask *task = m_downloadManager->getTask(taskId);
     if (task) {
-        // ui->taskTable->updateTask(task); // 已注释
+        ui->taskTable->updateTask(task);
         LOG_INFO(QString("任务恢复 - ID: %1").arg(taskId));
     }
 }
@@ -273,7 +273,7 @@ void MainWindow::onTaskCompleted(const QString &taskId)
 {
     DownloadTask *task = m_downloadManager->getTask(taskId);
     if (task) {
-        // ui->taskTable->updateTask(task); // 已注释
+        ui->taskTable->updateTask(task);
         LOG_INFO(QString("任务完成 - ID: %1").arg(taskId));
         showInfo(tr("下载完成：%1").arg(task->fileName()));
         loadTasks();
@@ -284,7 +284,7 @@ void MainWindow::onTaskFailed(const QString &taskId, const QString &error)
 {
     DownloadTask *task = m_downloadManager->getTask(taskId);
     if (task) {
-        // ui->taskTable->updateTask(task); // 已注释
+        ui->taskTable->updateTask(task);
         LOG_WARNING(QString("任务失败 - ID: %1, 错误: %2").arg(taskId).arg(error));
         showError(tr("下载失败：%1 - %2").arg(task->fileName()).arg(error));
         loadTasks();
@@ -295,7 +295,7 @@ void MainWindow::onTaskCancelled(const QString &taskId)
 {
     DownloadTask *task = m_downloadManager->getTask(taskId);
     if (task) {
-        // ui->taskTable->updateTask(task); // 已注释
+        ui->taskTable->updateTask(task);
         LOG_INFO(QString("任务取消 - ID: %1").arg(taskId));
         loadTasks();
     }
@@ -315,7 +315,7 @@ void MainWindow::onUpdateTimer()
         if (item) {
             DownloadTask *task = static_cast<DownloadTask*>(item->data(Qt::UserRole).value<void*>());
             if (task) {
-                // ui->taskTable->updateTask(task); // 已注释
+                ui->taskTable->updateTask(task);
             }
         }
     }

--- a/src/tasktablewidget.cpp
+++ b/src/tasktablewidget.cpp
@@ -12,7 +12,7 @@ TaskTableWidget::TaskTableWidget(QWidget *parent)
 
 void TaskTableWidget::setupTable()
 {
-    setColumnCount(6);
+    setColumnCount(7);
     setHorizontalHeaderLabels({tr("文件名"), tr("状态"), tr("进度"),
                                tr("速度"), tr("大小"), tr("剩余时间"), tr("操作")});
 
@@ -27,6 +27,7 @@ void TaskTableWidget::setupTable()
     horizontalHeader()->setSectionResizeMode(3, QHeaderView::ResizeToContents);
     horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
     horizontalHeader()->setSectionResizeMode(5, QHeaderView::ResizeToContents);
+    horizontalHeader()->setSectionResizeMode(6, QHeaderView::ResizeToContents);
 }
 
 void TaskTableWidget::addTask(DownloadTask *task)
@@ -121,12 +122,12 @@ void TaskTableWidget::createOperationButtons(int row, DownloadTask *task)
     layout->addWidget(resumeButton);
     layout->addWidget(cancelButton);
 
-    setCellWidget(row, 5, widget);
+    setCellWidget(row, 6, widget);
 }
 
 void TaskTableWidget::updateOperationButtons(int row, DownloadTask *task)
 {
-    QWidget *widget = cellWidget(row, 5);
+    QWidget *widget = cellWidget(row, 6);
     if (!widget) return;
 
     QList<QPushButton*> buttons = widget->findChildren<QPushButton*>();


### PR DESCRIPTION
## Summary
- display operation column in the task table by setting column count to 7
- adjust column indexes for operation buttons
- refresh table rows when task state changes

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685b565bb388833196df371af57c4784