### PR TITLE
Improve table elide handling

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -106,6 +106,10 @@ void MainWindow::setupUI()
     ui->completedTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents); // 文件名
     ui->completedTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);         // 文件路径
     ui->completedTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents); // 大小
+
+    ui->completedTable->setTextElideMode(Qt::ElideMiddle);
+    ui->completedTable->setWordWrap(false);
+    ui->completedTable->horizontalHeader()->setMaximumSectionSize(400);
     // 右键菜单
     ui->completedTable->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->completedTable, &QTableWidget::customContextMenuRequested, this, [this](const QPoint &pos) {
@@ -450,7 +454,10 @@ void MainWindow::loadTasks()
         if (task->status() == DownloadTask::Completed || task->status() == DownloadTask::Failed || task->status() == DownloadTask::Cancelled) {
             int row = ui->completedTable->rowCount();
             ui->completedTable->insertRow(row);
-            ui->completedTable->setItem(row, 0, new QTableWidgetItem(task->fileName()));
+            QTableWidgetItem *nameItem = new QTableWidgetItem(task->fileName());
+            nameItem->setToolTip(task->fileName());
+            ui->completedTable->setItem(row, 0, nameItem);
+
             ui->completedTable->setItem(row, 1, new QTableWidgetItem(task->savePath()));
             ui->completedTable->setItem(row, 2, new QTableWidgetItem(formatBytes(task->downloadedSize())));
             LOG_INFO(QString("已插入到已完成任务表格 - ID: %1, 行: %2").arg(task->id()).arg(row));

--- a/src/tasktablewidget.cpp
+++ b/src/tasktablewidget.cpp
@@ -28,6 +28,13 @@ void TaskTableWidget::setupTable()
     horizontalHeader()->setSectionResizeMode(4, QHeaderView::ResizeToContents);
     horizontalHeader()->setSectionResizeMode(5, QHeaderView::ResizeToContents);
     horizontalHeader()->setSectionResizeMode(6, QHeaderView::ResizeToContents);
+
+    // Display long file names with ellipsis in the middle
+    setTextElideMode(Qt::ElideMiddle);
+    setWordWrap(false);
+
+    // Limit the maximum width of the file name column
+    horizontalHeader()->setMaximumSectionSize(400);
 }
 
 void TaskTableWidget::addTask(DownloadTask *task)
@@ -36,6 +43,7 @@ void TaskTableWidget::addTask(DownloadTask *task)
     insertRow(row);
 
     QTableWidgetItem *fileNameItem = new QTableWidgetItem(task->fileName());
+    fileNameItem->setToolTip(task->fileName());
     fileNameItem->setData(Qt::UserRole, QVariant::fromValue(static_cast<void*>(task)));
     setItem(row, 0, fileNameItem);
 
@@ -82,6 +90,7 @@ void TaskTableWidget::updateTask(DownloadTask *task)
         return;
 
     item(row,0)->setText(task->fileName());
+    item(row,0)->setToolTip(task->fileName());
     item(row,1)->setText(task->statusText());
 
     QProgressBar *progressBar = qobject_cast<QProgressBar*>(cellWidget(row,2));


### PR DESCRIPTION
## Summary
- show tooltip with full file name for active tasks
- ellide long file names in TaskTableWidget
- elide and add tooltips for completed tasks

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5f23c1188331a13ccb110fa0a72d