### PR TITLE
Fix JSON not updated after removing tasks

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -122,6 +122,7 @@ void DownloadManager::removeTask(const QString &taskId)
     
     LOG_INFO(QString("任务已移除 - ID: %1").arg(taskId));
     emit taskRemoved(taskId);
+    saveTasks();
 }
 
 void DownloadManager::removeCompletedTasks()


### PR DESCRIPTION
## Summary
- update `removeTask` to persist config after deleting a task

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6899c4d08331bd321911cdb2a2a3