### PR TITLE
Remove unused clear button

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -204,7 +204,6 @@ void MainWindow::setupConnections()
 {
     // 连接 UI 信号
     connect(ui->browseButton, &QPushButton::clicked, this, &MainWindow::onBrowseClicked);
-    connect(ui->clearButton, &QPushButton::clicked, this, &MainWindow::onClearClicked);
     connect(ui->addTaskButton, &QPushButton::clicked, this, &MainWindow::onAddTaskButtonClicked);
     connect(ui->startAllButton, &QPushButton::clicked, this, &MainWindow::onStartAllClicked);
     connect(ui->pauseAllButton, &QPushButton::clicked, this, &MainWindow::onPauseAllClicked);
@@ -248,13 +247,6 @@ void MainWindow::onBrowseClicked()
         m_downloadManager->setDefaultSavePath(dir);
         LOG_INFO(QString("选择保存路径: %1").arg(dir));
     }
-}
-
-void MainWindow::onClearClicked()
-{
-    LOG_INFO("清空输入");
-    ui->savePathEdit->setText(m_downloadManager->getDefaultSavePath());
-    // 已移除 remoteFileTable 相关代码
 }
 
 void MainWindow::onStartAllClicked()

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -62,7 +62,6 @@ private:
     void setupConnections();
     void loadTasks();
     void updateStatusBar();
-    void onClearClicked();
     void onStartAllClicked();
     void onPauseAllClicked();
     void onRemoveClicked();

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -84,14 +84,7 @@
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="clearButton">
-               <property name="text">
-                <string>清空</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <spacer name="horizontalSpacer">
+             <spacer name="horizontalSpacer">
                <property name="orientation">
                 <enum>Qt::Orientation::Horizontal</enum>
                </property>


### PR DESCRIPTION
## Summary
- remove the Clear button from the UI
- drop connection and handler for the Clear button
- fix layout after removing the widget

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6ab2e0608331bf599f606cdac22d