### PR TITLE
Implement dated subdirectory creation

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -19,6 +19,9 @@
 #include <QTableWidgetItem>
 #include <QHeaderView>
 #include <QUrl>
+#include <QDir>
+#include <QFileInfo>
+#include <QDate>
 #include <QInputDialog>
 
 static QString toUncPath(QString path)
@@ -429,6 +432,20 @@ QString MainWindow::formatBytes(qint64 bytes) const
     }
 }
 
+QString MainWindow::buildFinalSavePath(const QString &basePath) const
+{
+    QString dateDir = QDate::currentDate().toString("MM_dd");
+    QString result = QDir(basePath).filePath(dateDir);
+
+    QString sub = ui->subDirEdit->text().trimmed();
+    if (!sub.isEmpty()) {
+        result = QDir(result).filePath(sub);
+    }
+
+    QDir().mkpath(result);
+    return result;
+}
+
 void MainWindow::fetchSmbFileList(const QString &url)
 {
     // 这里原本有 remoteFileTable 的相关操作，已移除
@@ -443,6 +460,8 @@ void MainWindow::onDownloadFileClicked(const QString &fileUrl)
     if (savePath.isEmpty())
         savePath = m_downloadManager->getDefaultSavePath();
 
+    savePath = buildFinalSavePath(savePath);
+
     // 添加任务后立即启动下载，避免用户还需手动点击开始
     QString taskId = m_downloadManager->addTask(fileUrl, savePath);
     m_downloadManager->startTask(taskId);
@@ -455,6 +474,8 @@ void MainWindow::onDownloadDirectoryClicked(const QString &dirUrl)
     QString savePath = ui->savePathEdit->text().trimmed();
     if (savePath.isEmpty())
         savePath = m_downloadManager->getDefaultSavePath();
+
+    savePath = buildFinalSavePath(savePath);
 
     QString dirName = QUrl(dirUrl).fileName();
     if (dirName.isEmpty()) {
@@ -600,6 +621,7 @@ void MainWindow::onAddTaskButtonClicked()
     if (savePath.isEmpty()) {
         savePath = m_downloadManager->getDefaultSavePath();
     }
+    savePath = buildFinalSavePath(savePath);
     QString taskId = m_downloadManager->addTask(url, savePath);
     m_downloadManager->startTask(taskId);
     // 立即刷新表格

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -74,6 +74,8 @@ private:
     void fetchSmbFileList(const QString &url);
     void downloadDirectoryRecursive(const QString &dirUrl, const QString &localPath);
 
+    QString buildFinalSavePath(const QString &basePath) const;
+
     void createTrayIcon();
     void createTrayMenu();
 

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -74,7 +74,21 @@
              </item>
             </layout>
            </item>
-           <item row="2" column="0" colspan="2">
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_sub">
+             <property name="text">
+              <string>子目录：</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLineEdit" name="subDirEdit">
+             <property name="placeholderText">
+              <string>可选，存放在日期目录下</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0" colspan="2">
             <layout class="QHBoxLayout" name="horizontalLayout_2">
              <item>
               <widget class="QPushButton" name="addTaskButton">


### PR DESCRIPTION
## Summary
- add `buildFinalSavePath` helper to auto-create `MM_dd` directory and optional subdir
- update add/download methods to use the helper
- extend UI with new subdirectory input

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b6b87f5dc8331bf671ba39247b2bd