### PR TITLE
Optimize SMB worker buffer and logging

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -137,7 +137,6 @@ void Logger::writeToFile(const QString &message)
     QMutexLocker locker(&m_writeMutex);
     
     if (m_logFile.isOpen()) {
-        m_textStream << message << Qt::endl;
-        m_textStream.flush();
+        m_textStream << message << '\n';
     }
 } 

--- a/src/smbworker.cpp
+++ b/src/smbworker.cpp
@@ -95,7 +95,7 @@ void SmbWorker::run()
     LOG_INFO(QString("SmbWorker: remoteFile.size() = %1").arg(total));
     emit progress(m_offset, total);
 
-    const int bufSize = 4096;
+    const int bufSize = 65536;
     char buf[bufSize];
     qint64 received = m_offset;
 
@@ -104,9 +104,7 @@ void SmbWorker::run()
             msleep(100);
             continue;
         }
-        LOG_INFO("SmbWorker: 读取数据前");
         qint64 n = remoteFile.read(buf, bufSize);
-        LOG_INFO(QString("SmbWorker: 读取数据 n = %1").arg(n));
         if (n < 0) {
             remoteFile.close();
             file.close();


### PR DESCRIPTION
## Summary
- reduce file logging flushes by removing `Qt::endl` and manual flush
- enlarge SMB read buffer to 64KiB and remove per-read log spam

## Testing
- `qmake --version` *(fails: command not found)*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685b91789030833199574234e89b500d