### PR TITLE
Implement cleanup for cancelled downloads

### DIFF
--- a/src/smbdownloader.cpp
+++ b/src/smbdownloader.cpp
@@ -3,6 +3,7 @@
 #include "smbworker.h"
 #include <QFileInfo>
 #include <QDir>
+#include <QFile>
 #include <QStandardPaths>
 #include <QMessageBox>
 #include <QApplication>
@@ -152,7 +153,18 @@ void SmbDownloader::cancelDownload(DownloadTask *task)
         info->worker->requestCancel();
         info->worker->wait();
     }
-    
+
+    // 删除已下载的部分文件
+    QUrl url(task->url());
+    QString filePath = task->savePath();
+    if (!filePath.endsWith('/') && !filePath.endsWith('\\'))
+        filePath += '/';
+    QString fileName = url.fileName();
+    if (fileName.isEmpty())
+        fileName = "downloaded_file";
+    filePath += fileName;
+    QFile::remove(filePath);
+
     task->setStatus(DownloadTask::Cancelled);
     cleanupDownload(task);
     


### PR DESCRIPTION
## Summary
- remove partial file when cancelling SMB download
- include missing header for QFile

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b9147e1248331b18c4b70f3f79454