### PR TITLE
Fix resume button logic

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -224,10 +224,10 @@ void DownloadManager::resumeTask(const QString &taskId)
     }
     
     m_activeDownloadCount++;
-    task->setStatus(DownloadTask::Downloading);
-    
+
     LOG_INFO(QString("任务恢复下载 - ID: %1, 当前活跃下载数: %2").arg(taskId).arg(m_activeDownloadCount));
-    
+
+    // 调用下载器恢复任务，状态将在下载器中更新
     m_smbDownloader->resumeDownload(task);
 }
 

--- a/src/smbdownloader.cpp
+++ b/src/smbdownloader.cpp
@@ -132,10 +132,12 @@ void SmbDownloader::resumeDownload(DownloadTask *task)
     DownloadInfo *info = findDownloadInfo(task);
     if (info && info->worker) {
         info->worker->resumeWork();
+        task->setStatus(DownloadTask::Downloading);
+        emit downloadResumed(task);
     } else {
+        // 若未找到下载信息，重新开始下载
         startDownload(task);
     }
-    emit downloadResumed(task);
 }
 
 void SmbDownloader::cancelDownload(DownloadTask *task)


### PR DESCRIPTION
## Summary
- fix task resume button by updating resume logic

## Testing
- `pytest -q` *(fails: no tests ran)*
- `qmake DownloadAssistant.pro` *(fails: qmake not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b98370ab4833180d5f01127fd0357