### PR TITLE
Open file browser at typed SMB path

### DIFF
--- a/src/filebrowserdialog.cpp
+++ b/src/filebrowserdialog.cpp
@@ -4,11 +4,13 @@
 #include <QVBoxLayout>
 #include <QDialogButtonBox>
 
-FileBrowserDialog::FileBrowserDialog(QWidget *parent)
+FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
     : QDialog(parent), m_model(new QFileSystemModel(this)), m_view(new QTreeView(this))
 {
-    m_model->setRootPath(QString());
+    QModelIndex rootIndex = m_model->setRootPath(rootPath);
     m_view->setModel(m_model);
+    if (rootIndex.isValid())
+        m_view->setRootIndex(rootIndex);
     m_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
 
     auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);

--- a/src/filebrowserdialog.h
+++ b/src/filebrowserdialog.h
@@ -10,7 +10,7 @@ class FileBrowserDialog : public QDialog
 {
     Q_OBJECT
 public:
-    explicit FileBrowserDialog(QWidget *parent = nullptr);
+    explicit FileBrowserDialog(const QString &rootPath = QString(), QWidget *parent = nullptr);
     QStringList selectedPaths() const;
 
 private:

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -618,7 +618,12 @@ void MainWindow::closeEvent(QCloseEvent *event)
 
 void MainWindow::onBrowseSmbButtonClicked()
 {
-    FileBrowserDialog dialog(this);
+    QString url = ui->urlEdit->text().trimmed();
+    if (url.isEmpty()) {
+        showWarning(tr("请输入下载地址"));
+        return;
+    }
+    FileBrowserDialog dialog(toUncPath(url), this);
     if (dialog.exec() != QDialog::Accepted)
         return;
 


### PR DESCRIPTION
## Summary
- allow FileBrowserDialog to accept a root path
- open the remote file browser at the path the user typed
- warn if the download address field is empty before browsing

## Testing
- `qmake && make -j$(nproc)` *(fails: `qmake: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b9c3b3bf48331936bb6bbe818d208