### PR TITLE
Fix JSON config not saved after task completion

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -482,6 +482,7 @@ void DownloadManager::onDownloadCancelled(DownloadTask *task)
     task->setErrorMessage(tr("用户取消"));
     emit taskCancelled(task->id());
     processNextTask();
+    saveTasks();
 }
 
 void DownloadManager::onDownloadCompleted(DownloadTask *task)
@@ -491,6 +492,7 @@ void DownloadManager::onDownloadCompleted(DownloadTask *task)
     task->setStatus(DownloadTask::Completed);
     emit taskCompleted(task->id());
     processNextTask();
+    saveTasks();
 }
 
 void DownloadManager::onDownloadFailed(DownloadTask *task, const QString &error)
@@ -501,6 +503,7 @@ void DownloadManager::onDownloadFailed(DownloadTask *task, const QString &error)
     task->setErrorMessage(error);
     emit taskFailed(task->id(), error);
     processNextTask();
+    saveTasks();
 }
 
 void DownloadManager::onDownloadProgress(DownloadTask *task, qint64 bytesReceived, qint64 bytesTotal)


### PR DESCRIPTION
## Summary
- ensure config is stored when tasks finish

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba2c8fc088331bebf7aa93558b861