### PR TITLE
Add concurrency configuration UI

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -352,6 +352,11 @@ int DownloadManager::getMaxConcurrentDownloads() const
 
 void DownloadManager::setMaxConcurrentDownloads(int max)
 {
+    if (max < 3) {
+        max = 3;
+    } else if (max > 8) {
+        max = 8;
+    }
     m_maxConcurrentDownloads = max;
     saveTasks();
 }
@@ -410,7 +415,7 @@ void DownloadManager::loadTasks()
         QJsonObject json = jsonDoc.object();
         QJsonArray tasksArray = json["tasks"].toArray();
         m_defaultSavePath = json["defaultSavePath"].toString();
-        m_maxConcurrentDownloads = json["maxConcurrentDownloads"].toInt();
+        setMaxConcurrentDownloads(json["maxConcurrentDownloads"].toInt());
         for (const QJsonValue &value : tasksArray) {
             QJsonObject taskObject = value.toObject();
             QString id = taskObject["id"].toString();

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -17,7 +17,7 @@ DownloadManager::DownloadManager(QObject *parent)
     : QObject(parent)
     , m_smbDownloader(new SmbDownloader(this))
     , m_configPath(QCoreApplication::applicationDirPath() + "/config.json")
-    , m_maxConcurrentDownloads(3)
+    , m_maxConcurrentDownloads(5)
     , m_activeDownloadCount(0)
 {
     LOG_INFO("DownloadManager 初始化开始");

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -25,6 +25,7 @@
 #include <QDate>
 #include <QInputDialog>
 #include <QDesktopServices>
+#include <QSpinBox>
 
 static QString toUncPath(QString path)
 {
@@ -63,6 +64,9 @@ MainWindow::MainWindow(QWidget *parent)
     
     // 设置默认保存路径
     ui->savePathEdit->setText(m_downloadManager->getDefaultSavePath());
+    ui->concurrencySpinBox->setValue(m_downloadManager->getMaxConcurrentDownloads());
+    connect(ui->concurrencySpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
+            m_downloadManager, &DownloadManager::setMaxConcurrentDownloads);
     
     // 启动更新定时器
     m_updateTimer->setInterval(1000); // 每秒更新一次

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -98,10 +98,10 @@
            <item row="3" column="1">
             <widget class="QSpinBox" name="concurrencySpinBox">
              <property name="minimum">
-              <number>1</number>
+              <number>3</number>
              </property>
              <property name="maximum">
-              <number>50</number>
+              <number>8</number>
              </property>
              <property name="value">
               <number>5</number>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -88,7 +88,27 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="0" colspan="2">
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_concurrency">
+             <property name="text">
+              <string>并发线程数：</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QSpinBox" name="concurrencySpinBox">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>50</number>
+             </property>
+             <property name="value">
+              <number>5</number>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0" colspan="2">
             <layout class="QHBoxLayout" name="horizontalLayout_2">
              <item>
               <widget class="QPushButton" name="addTaskButton">


### PR DESCRIPTION
## Summary
- allow tuning max concurrent downloads via new spin box
- default to 5 concurrent threads

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba3fd6a048331b1e38d4b7b965d8d