### PR TITLE
Prevent SMB browse from altering download URL

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -633,10 +633,15 @@ void MainWindow::onBrowseSmbButtonClicked()
 
     if (paths.size() == 1) {
         QFileInfo info(paths.first());
-        ui->urlEdit->setText(paths.first());
         if (info.isDir()) {
             onDownloadDirectoryClicked(paths.first());
+        } else {
+            onDownloadFileClicked(paths.first());
         }
+
+        loadTasks();
+        updateStatusBar();
+        showInfo(tr("已添加下载任务"));
         return;
     }
 


### PR DESCRIPTION
## Summary
- do not replace the URL entry when choosing files or directories with the SMB browser
- automatically start the selected download

## Testing
- `make --version | head -n 1`
- `g++ --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_685ba3a0a69c8331ac8857e7413fe556