### PR TITLE
Fix queued task operation buttons

### DIFF
--- a/src/tasktablewidget.cpp
+++ b/src/tasktablewidget.cpp
@@ -152,6 +152,12 @@ void TaskTableWidget::updateOperationButtons(int row, DownloadTask *task)
         resumeButton->setVisible(false);
         cancelButton->setVisible(true);
         break;
+    case DownloadTask::Queued:
+        startButton->setVisible(false);
+        pauseButton->setVisible(false);
+        resumeButton->setVisible(false);
+        cancelButton->setVisible(true);
+        break;
     case DownloadTask::Downloading:
         startButton->setVisible(false);
         pauseButton->setVisible(true);


### PR DESCRIPTION
## Summary
- hide unnecessary buttons when a task is queued

## Testing
- `qmake DownloadAssistant.pro` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685babe61ef08331bca52e9c300b6fc7