### PR TITLE
Move directory download scanning to background thread

### DIFF
--- a/DownloadAssistant.pro
+++ b/DownloadAssistant.pro
@@ -22,6 +22,7 @@ SOURCES += \
     src/downloadtask.cpp \
     src/smbdownloader.cpp \
     src/smbworker.cpp \
+    src/directoryworker.cpp \
     src/logger.cpp \
     src/tasktablewidget.cpp \
     src/filebrowserdialog.cpp
@@ -34,7 +35,8 @@ HEADERS += \
     src/smbworker.h \
     src/logger.h \
     src/tasktablewidget.h \
-    src/filebrowserdialog.h
+    src/filebrowserdialog.h \
+    src/directoryworker.h
 
 FORMS += \
     src/mainwindow.ui

--- a/src/directoryworker.cpp
+++ b/src/directoryworker.cpp
@@ -1,0 +1,66 @@
+#include "directoryworker.h"
+#include "downloadmanager.h"
+#include <QDir>
+#include <QFileInfo>
+#include <QUrl>
+#include "logger.h"
+
+static QString toUncPath(QString path)
+{
+    path.remove('\r');
+    path.remove('\n');
+    path = path.trimmed();
+    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
+        QUrl u(path);
+        QString p = u.path();
+        if (p.startsWith('/'))
+            p.remove(0, 1);
+        p.replace('/', '\\');
+        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
+    }
+    path.replace('/', '\\');
+    return path;
+}
+
+DirectoryWorker::DirectoryWorker(const QString &dirUrl, const QString &localPath,
+                                 DownloadManager *manager, QObject *parent)
+    : QThread(parent), m_dirUrl(dirUrl), m_localPath(localPath), m_manager(manager)
+{
+}
+
+void DirectoryWorker::run()
+{
+    scanDirectory(m_dirUrl, m_localPath);
+    emit finished();
+}
+
+void DirectoryWorker::scanDirectory(const QString &dirUrl, const QString &localPath)
+{
+    if (!m_manager)
+        return;
+
+    QString uncPath = toUncPath(dirUrl);
+    QDir dir(uncPath);
+    if (!dir.exists())
+        return;
+
+    QDir().mkpath(localPath);
+
+    QFileInfoList list = dir.entryInfoList(QDir::AllEntries | QDir::NoDotAndDotDot);
+    for (const QFileInfo &info : list) {
+        QString name = info.fileName();
+        QString childUrl = dirUrl;
+        if (!childUrl.endsWith('/'))
+            childUrl += '/';
+        childUrl += name;
+
+        if (info.isDir()) {
+            QString subLocal = QDir(localPath).filePath(name);
+            scanDirectory(childUrl, subLocal);
+        } else {
+            QString taskId = m_manager->addTask(childUrl, localPath);
+            m_manager->startTask(taskId);
+        }
+    }
+}
+

--- a/src/directoryworker.h
+++ b/src/directoryworker.h
@@ -1,0 +1,30 @@
+#ifndef DIRECTORYWORKER_H
+#define DIRECTORYWORKER_H
+
+#include <QThread>
+#include <QString>
+
+class DownloadManager;
+
+class DirectoryWorker : public QThread
+{
+    Q_OBJECT
+public:
+    DirectoryWorker(const QString &dirUrl, const QString &localPath,
+                    DownloadManager *manager, QObject *parent = nullptr);
+
+signals:
+    void finished();
+
+protected:
+    void run() override;
+
+private:
+    void scanDirectory(const QString &dirUrl, const QString &localPath);
+
+    QString m_dirUrl;
+    QString m_localPath;
+    DownloadManager *m_manager;
+};
+
+#endif // DIRECTORYWORKER_H

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -71,7 +71,6 @@ private:
     void showError(const QString &message);
     QString formatBytes(qint64 bytes) const;
     void fetchSmbFileList(const QString &url);
-    void downloadDirectoryRecursive(const QString &dirUrl, const QString &localPath);
 
     QString buildFinalSavePath(const QString &basePath) const;
 


### PR DESCRIPTION
## Summary
- add `DirectoryWorker` thread for asynchronous directory scanning
- use `DirectoryWorker` in `MainWindow` when adding directory downloads
- remove old recursive function and update project file

## Testing
- `qmake DownloadAssistant.pro -o Makefile` *(fails: command not found)*
- `make -j$(nproc)` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685bacd658388331ae9460f0653e6aa4