### PR TITLE
Fix concurrency load from config

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -415,7 +415,13 @@ void DownloadManager::loadTasks()
         QJsonObject json = jsonDoc.object();
         QJsonArray tasksArray = json["tasks"].toArray();
         m_defaultSavePath = json["defaultSavePath"].toString();
-        setMaxConcurrentDownloads(json["maxConcurrentDownloads"].toInt());
+        int max = json["maxConcurrentDownloads"].toInt(m_maxConcurrentDownloads);
+        if (max < 3) {
+            max = 3;
+        } else if (max > 8) {
+            max = 8;
+        }
+        m_maxConcurrentDownloads = max;
         for (const QJsonValue &value : tasksArray) {
             QJsonObject taskObject = value.toObject();
             QString id = taskObject["id"].toString();


### PR DESCRIPTION
## Summary
- assign `maxConcurrentDownloads` directly when loading config
- validate bounds without saving

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile)*

------
https://chatgpt.com/codex/tasks/task_e_685baeca9b0c8331abe1afa84a4c67fe