### PR TITLE
Ensure task state is saved on pause/resume

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -198,8 +198,9 @@ void DownloadManager::pauseTask(const QString &taskId)
     LOG_INFO(QString("任务已暂停 - ID: %1, 当前活跃下载数: %2").arg(taskId).arg(m_activeDownloadCount));
     
     m_smbDownloader->pauseDownload(task);
-    
+
     processNextTask();
+    saveTasks();
 }
 
 void DownloadManager::resumeTask(const QString &taskId)
@@ -229,6 +230,7 @@ void DownloadManager::resumeTask(const QString &taskId)
 
     // 调用下载器恢复任务，状态将在下载器中更新
     m_smbDownloader->resumeDownload(task);
+    saveTasks();
 }
 
 void DownloadManager::cancelTask(const QString &taskId)


### PR DESCRIPTION
## Summary
- persist task list when pausing or resuming a download

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baecd72c483318ce6a9cae406aea8