### PR TITLE
Improve invalid path handling for SMB browsing

### DIFF
--- a/src/filebrowserdialog.cpp
+++ b/src/filebrowserdialog.cpp
@@ -5,6 +5,7 @@
 #include <QDialogButtonBox>
 #include <QHeaderView>
 #include <QTimer>
+#include <QMessageBox>
 
 FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
     : QDialog(parent)
@@ -18,8 +19,13 @@ FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
     // 延迟加载实际的远程根目录，以减少界面卡顿
     QTimer::singleShot(0, this, [this, rootPath] {
         QModelIndex rootIndex = m_model->setRootPath(rootPath);
-        if (rootIndex.isValid())
+        if (rootIndex.isValid()) {
             m_view->setRootIndex(rootIndex);
+        } else {
+            QMessageBox::critical(this, tr("错误"),
+                                  tr("目录不存在: %1").arg(rootPath));
+            reject();
+        }
     });
 
     m_view->setSelectionMode(QAbstractItemView::ExtendedSelection);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -614,7 +614,13 @@ void MainWindow::onBrowseSmbButtonClicked()
         showWarning(tr("请输入下载地址"));
         return;
     }
-    FileBrowserDialog dialog(toUncPath(url), this);
+    QString uncPath = toUncPath(url);
+    if (!QDir(uncPath).exists()) {
+        showError(tr("目录不存在：%1").arg(url));
+        return;
+    }
+
+    FileBrowserDialog dialog(uncPath, this);
     if (dialog.exec() != QDialog::Accepted)
         return;
 


### PR DESCRIPTION
## Summary
- show an error if the SMB path doesn't exist
- prevent file browser from falling back to the default drive when path is invalid

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb4409974833186096ef031f52ec5