### PR TITLE
Remove unused Add Task button

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -230,7 +230,6 @@ void MainWindow::setupConnections()
 {
     // 连接 UI 信号
     connect(ui->browseButton, &QPushButton::clicked, this, &MainWindow::onBrowseClicked);
-    connect(ui->addTaskButton, &QPushButton::clicked, this, &MainWindow::onAddTaskButtonClicked);
     connect(ui->startAllButton, &QPushButton::clicked, this, &MainWindow::onStartAllClicked);
     connect(ui->pauseAllButton, &QPushButton::clicked, this, &MainWindow::onPauseAllClicked);
     connect(ui->browseSmbButton, &QPushButton::clicked, this, &MainWindow::onBrowseSmbButtonClicked);
@@ -662,25 +661,6 @@ void MainWindow::onBrowseSmbButtonClicked()
     showInfo(tr("已添加下载任务"));
 }
 
-void MainWindow::onAddTaskButtonClicked()
-{
-    QString url = ui->urlEdit->text().trimmed();
-    QString savePath = ui->savePathEdit->text().trimmed();
-    if (url.isEmpty()) {
-        showWarning(tr("请输入下载地址"));
-        return;
-    }
-    if (savePath.isEmpty()) {
-        savePath = m_downloadManager->getDefaultSavePath();
-    }
-    savePath = buildFinalSavePath(savePath);
-    QString taskId = m_downloadManager->addTask(url, savePath);
-    m_downloadManager->startTask(taskId);
-    // 立即刷新表格
-    loadTasks();
-    updateStatusBar();
-    showInfo(tr("已添加下载任务"));
-}
 
 void MainWindow::onTaskProgress(const QString &taskId, qint64 bytesReceived, qint64 bytesTotal)
 {

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -26,7 +26,6 @@ private slots:
     // UI 事件处理
     void onBrowseClicked();
     void onBrowseSmbButtonClicked();
-    void onAddTaskButtonClicked();
     
     // 下载管理器事件
     void onTaskAdded(const QString &taskId);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -108,30 +108,6 @@
              </property>
             </widget>
            </item>
-           <item row="4" column="0" colspan="2">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <item>
-              <widget class="QPushButton" name="addTaskButton">
-               <property name="text">
-                <string>添加下载任务</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-             <spacer name="horizontalSpacer">
-               <property name="orientation">
-                <enum>Qt::Orientation::Horizontal</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>40</width>
-                 <height>20</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </item>
           </layout>
          </widget>
         </item>


### PR DESCRIPTION
## Summary
- remove the Add Task button from the main window UI
- delete the related slot and signal connection

## Testing
- `qmake DownloadAssistant.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb54012a48331b1618c9d0c51a636