### PR TITLE
Implement threaded SMB path existence check

### DIFF
--- a/DownloadAssistant.pro
+++ b/DownloadAssistant.pro
@@ -25,7 +25,8 @@ SOURCES += \
     src/directoryworker.cpp \
     src/logger.cpp \
     src/tasktablewidget.cpp \
-    src/filebrowserdialog.cpp
+    src/filebrowserdialog.cpp \
+    src/smbpathchecker.cpp
 
 HEADERS += \
     src/mainwindow.h \
@@ -36,7 +37,8 @@ HEADERS += \
     src/logger.h \
     src/tasktablewidget.h \
     src/filebrowserdialog.h \
-    src/directoryworker.h
+    src/directoryworker.h \
+    src/smbpathchecker.h
 
 FORMS += \
     src/mainwindow.ui

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -9,6 +9,8 @@
 #include <QSettings>
 #include "downloadmanager.h"
 #include "tasktablewidget.h"
+#include "smbpathchecker.h"
+#include <QThread>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -44,6 +46,7 @@ private slots:
     void onTrayIconActivated(QSystemTrayIcon::ActivationReason reason);
     void onDownloadFileClicked(const QString &fileName);
     void onDownloadDirectoryClicked(const QString &dirUrl);
+    void onSmbPathCheckFinished(bool exists, const QString &uncPath);
 
 private:
     // UI 组件
@@ -56,6 +59,8 @@ private:
     QSystemTrayIcon *m_trayIcon;
     QMenu *m_trayMenu;
     QSettings *m_settings;
+    QThread *m_smbCheckThread;
+    QString m_lastSmbUrl;
     
     // 辅助方法
     void setupUI();

--- a/src/smbpathchecker.cpp
+++ b/src/smbpathchecker.cpp
@@ -1,0 +1,33 @@
+#include "smbpathchecker.h"
+#include <QDir>
+#include <QUrl>
+
+static QString toUncPath(QString path)
+{
+    path.remove('\r');
+    path.remove('\n');
+    path = path.trimmed();
+    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
+        QUrl u(path);
+        QString p = u.path();
+        if (p.startsWith('/'))
+            p.remove(0, 1);
+        p.replace('/', '\\');
+        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
+    }
+    path.replace('/', '\\');
+    return path;
+}
+
+SmbPathChecker::SmbPathChecker(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void SmbPathChecker::check(const QString &path)
+{
+    QString uncPath = toUncPath(path);
+    bool ok = QDir(uncPath).exists();
+    emit finished(ok, uncPath);
+}
+

--- a/src/smbpathchecker.h
+++ b/src/smbpathchecker.h
@@ -1,0 +1,19 @@
+#ifndef SMBPATHCHECKER_H
+#define SMBPATHCHECKER_H
+
+#include <QObject>
+
+class SmbPathChecker : public QObject
+{
+    Q_OBJECT
+public:
+    explicit SmbPathChecker(QObject *parent = nullptr);
+
+public slots:
+    void check(const QString &path);
+
+signals:
+    void finished(bool exists, const QString &uncPath);
+};
+
+#endif // SMBPATHCHECKER_H


### PR DESCRIPTION
## Summary
- add `SmbPathChecker` worker object to verify SMB paths in a background thread
- start `SmbPathChecker` in `MainWindow::onBrowseSmbButtonClicked`
- open the file browser or show an error when the check finishes
- track the worker thread and clean it up in the destructor
- include new source files in the qmake project

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `qmake DownloadAssistant.pro && make -n` *(fails: qmake: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb8eef7cc8331b6c3f760cfbd8542