### PR TITLE
Persist last URL in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ DownloadAssistant 是一款基于 **Qt** 的 Windows 下载工具，具备断点
 
 运行 `DownloadAssistant.exe` 后，在界面中输入下载地址和本地保存路径，即可创建并启动下载任务。任务可随时暂停、继续或取消，并可批量操作。
 
-程序运行目录将自动生成 `config.ini` 与 `logs/downloadassistant.log`，分别用于保存设置和输出日志。
+程序运行目录将自动生成 `config.json` 与 `logs/downloadassistant.log`，分别用于保存任务和设置以及输出日志。
 程序还会记住上一次输入的下载地址，下次启动时自动填入。
 
 ## 开发计划

--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -19,6 +19,7 @@ DownloadManager::DownloadManager(QObject *parent)
     , m_configPath(QCoreApplication::applicationDirPath() + "/config.json")
     , m_maxConcurrentDownloads(5)
     , m_activeDownloadCount(0)
+    , m_lastUrl("")
 {
     LOG_INFO("DownloadManager 初始化开始");
     
@@ -363,6 +364,17 @@ void DownloadManager::setMaxConcurrentDownloads(int max)
     saveTasks();
 }
 
+QString DownloadManager::getLastUrl() const
+{
+    return m_lastUrl;
+}
+
+void DownloadManager::setLastUrl(const QString &url)
+{
+    m_lastUrl = url;
+    saveTasks();
+}
+
 void DownloadManager::saveTasks()
 {
     LOG_INFO("保存任务列表");
@@ -387,6 +399,7 @@ void DownloadManager::saveTasks()
     json["tasks"] = tasksArray;
     json["defaultSavePath"] = m_defaultSavePath;
     json["maxConcurrentDownloads"] = m_maxConcurrentDownloads;
+    json["lastUrl"] = m_lastUrl;
     
     QFile file(m_configPath);
     if (file.open(QIODevice::WriteOnly)) {
@@ -424,6 +437,7 @@ void DownloadManager::loadTasks()
             max = 8;
         }
         m_maxConcurrentDownloads = max;
+        m_lastUrl = json["lastUrl"].toString();
         for (const QJsonValue &value : tasksArray) {
             QJsonObject taskObject = value.toObject();
             QString id = taskObject["id"].toString();

--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -49,6 +49,10 @@ public:
     void setDefaultSavePath(const QString &path);
     int getMaxConcurrentDownloads() const;
     void setMaxConcurrentDownloads(int max);
+
+    // 最近一次输入的地址
+    QString getLastUrl() const;
+    void setLastUrl(const QString &url);
     
     // 持久化
     void saveTasks();
@@ -88,6 +92,7 @@ private:
     QString m_defaultSavePath;
     int m_maxConcurrentDownloads;
     int m_activeDownloadCount;
+    QString m_lastUrl;
     
     // 辅助方法
     void processNextTask();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -8,7 +8,6 @@
 #include <QApplication>
 #include <QSystemTrayIcon>
 #include <QMenu>
-#include <QSettings>
 #include <QCoreApplication>
 #include <QCloseEvent>
 #include <algorithm>
@@ -53,7 +52,6 @@ MainWindow::MainWindow(QWidget *parent)
     , m_taskModel(new QStandardItemModel(this))
     , m_trayIcon(nullptr)
     , m_trayMenu(nullptr)
-    , m_settings(new QSettings(QCoreApplication::applicationDirPath() + "/config.ini", QSettings::IniFormat, this))
     , m_smbCheckThread(nullptr)
 {
     LOG_INFO("MainWindow 初始化开始");
@@ -65,7 +63,7 @@ MainWindow::MainWindow(QWidget *parent)
     setupConnections();
 
     // 从配置中恢复上一次输入的下载地址
-    ui->urlEdit->setText(m_settings->value("lastUrl").toString());
+    ui->urlEdit->setText(m_downloadManager->getLastUrl());
     
     // 设置默认保存路径
     ui->savePathEdit->setText(m_downloadManager->getDefaultSavePath());
@@ -99,8 +97,7 @@ MainWindow::MainWindow(QWidget *parent)
 MainWindow::~MainWindow()
 {
     // 保存最后一次输入的下载地址
-    m_settings->setValue("lastUrl", ui->urlEdit->text());
-    m_settings->sync();
+    m_downloadManager->setLastUrl(ui->urlEdit->text());
     if (m_smbCheckThread) {
         m_smbCheckThread->quit();
         m_smbCheckThread->wait();

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -6,7 +6,6 @@
 #include <QTimer>
 #include <QSystemTrayIcon>
 #include <QMenu>
-#include <QSettings>
 #include "downloadmanager.h"
 #include "tasktablewidget.h"
 #include "smbpathchecker.h"
@@ -57,7 +56,6 @@ private:
     QTimer *m_updateTimer;
     QSystemTrayIcon *m_trayIcon;
     QMenu *m_trayMenu;
-    QSettings *m_settings;
     QThread *m_smbCheckThread;
     QString m_lastSmbUrl;
     


### PR DESCRIPTION
## Summary
- store last entered URL alongside other settings in `config.json`
- remove the separate `config.ini` handling
- update documentation to reflect configuration changes

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc01eb20c833183d0e948dceb6b08