### PR TITLE
Flush log stream after each write

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -138,5 +138,6 @@ void Logger::writeToFile(const QString &message)
     
     if (m_logFile.isOpen()) {
         m_textStream << message << '\n';
+        m_textStream.flush();
     }
-} 
+}


### PR DESCRIPTION
## Summary
- ensure log messages are written out immediately by calling `flush()` after writing to the log file

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc38b5de883318a9c7d32a80c54de