### PR TITLE
Update thread id logging

### DIFF
--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -109,6 +109,13 @@ QString Logger::levelToString(LogLevel level) const
 
 QString Logger::getCurrentThreadId() const
 {
+    QThread *current = QThread::currentThread();
+    QThread *mainThread = QCoreApplication::instance() ? QCoreApplication::instance()->thread() : nullptr;
+
+    if (current == mainThread) {
+        return "MainThread";
+    }
+
     return QString::number(reinterpret_cast<quintptr>(QThread::currentThreadId()));
 }
 


### PR DESCRIPTION
## Summary
- show `MainThread` instead of numeric id when logging from main thread

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc44854e083319621daf24f95d79a