### PR TITLE
Fix tray icon double-click behavior

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -587,12 +587,14 @@ void MainWindow::createTrayIcon()
 void MainWindow::onTrayIconActivated(QSystemTrayIcon::ActivationReason reason)
 {
     LOG_INFO("托盘图标被激活");
-    if (reason == QSystemTrayIcon::Trigger || reason == QSystemTrayIcon::DoubleClick) {
+    if (reason == QSystemTrayIcon::Trigger) {
         if (isHidden()) {
             showNormal();
         } else {
             hide();
         }
+    } else if (reason == QSystemTrayIcon::DoubleClick) {
+        showNormal();
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure double-clicking the tray icon always opens the main window

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc539e23083318859059ece87832e