### PR TITLE
Fix remote file browser not displaying contents

### DIFF
--- a/DownloadAssistant.pro
+++ b/DownloadAssistant.pro
@@ -26,7 +26,6 @@ SOURCES += \
     src/logger.cpp \
     src/tasktablewidget.cpp \
     src/filebrowserdialog.cpp \
-    src/smbdirmodelworker.cpp \
     src/smbpathchecker.cpp
 
 HEADERS += \
@@ -38,7 +37,6 @@ HEADERS += \
     src/logger.h \
     src/tasktablewidget.h \
     src/filebrowserdialog.h \
-    src/smbdirmodelworker.h \
     src/directoryworker.h \
     src/smbpathchecker.h
 

--- a/src/filebrowserdialog.cpp
+++ b/src/filebrowserdialog.cpp
@@ -7,46 +7,31 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QApplication>
-#include "smbdirmodelworker.h"
 
 FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
     : QDialog(parent)
-    , m_model(nullptr)
+    , m_model(new QFileSystemModel(this))
     , m_view(new QTreeView(this))
-    , m_thread(new QThread(this))
 {
     auto *buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
     buttons->setEnabled(false);
     connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-    // 在后台线程加载模型，避免阻塞主线程
-    auto *worker = new SmbDirModelWorker;
-    worker->moveToThread(m_thread);
-    connect(m_thread, &QThread::finished, worker, &QObject::deleteLater);
-    connect(worker, &SmbDirModelWorker::loaded, this,
-            [this, buttons](QFileSystemModel *model, const QString &path) {
-                model->moveToThread(QApplication::instance()->thread());
-                m_model = model;
-                m_view->setModel(m_model);
-                QModelIndex rootIndex = m_model->index(path);
-                if (rootIndex.isValid()) {
-                    m_view->setRootIndex(rootIndex);
-                } else {
-                    QMessageBox::critical(this, tr("错误"),
-                                          tr("目录不存在: %1").arg(path));
-                    reject();
-                }
-                // 调整列宽
-                QHeaderView *header = m_view->header();
-                header->setSectionResizeMode(0, QHeaderView::Stretch);
-                for (int i = 1; i < m_model->columnCount(); ++i)
-                    header->setSectionResizeMode(i, QHeaderView::ResizeToContents);
-                buttons->setEnabled(true);
-                m_thread->quit();
-            });
-    m_thread->start();
-    QMetaObject::invokeMethod(worker, "load", Qt::QueuedConnection, Q_ARG(QString, rootPath));
+    m_model->setRootPath(rootPath);
+    m_view->setModel(m_model);
+    QModelIndex rootIndex = m_model->index(rootPath);
+    if (rootIndex.isValid()) {
+        m_view->setRootIndex(rootIndex);
+        QHeaderView *header = m_view->header();
+        header->setSectionResizeMode(0, QHeaderView::Stretch);
+        for (int i = 1; i < m_model->columnCount(); ++i)
+            header->setSectionResizeMode(i, QHeaderView::ResizeToContents);
+        buttons->setEnabled(true);
+    } else {
+        QMessageBox::critical(this, tr("错误"), tr("目录不存在: %1").arg(rootPath));
+        buttons->setEnabled(false);
+    }
 
     auto *layout = new QVBoxLayout(this);
     layout->addWidget(m_view);
@@ -58,10 +43,6 @@ FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
 
 FileBrowserDialog::~FileBrowserDialog()
 {
-    if (m_thread->isRunning()) {
-        m_thread->quit();
-        m_thread->wait();
-    }
 }
 
 QStringList FileBrowserDialog::selectedPaths() const

--- a/src/filebrowserdialog.h
+++ b/src/filebrowserdialog.h
@@ -2,9 +2,6 @@
 #define FILEBROWSERDIALOG_H
 
 #include <QDialog>
-#include <QThread>
-
-class SmbDirModelWorker;
 
 class QFileSystemModel;
 class QTreeView;
@@ -20,7 +17,6 @@ public:
 private:
     QFileSystemModel *m_model;
     QTreeView *m_view;
-    QThread *m_thread;
 };
 
 #endif // FILEBROWSERDIALOG_H


### PR DESCRIPTION
## Summary
- create `QFileSystemModel` directly in GUI thread
- simplify `FileBrowserDialog` implementation
- stop compiling unused `smbdirmodelworker`

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be758a4288331aa738c86879395a0