### PR TITLE
Use info level for all debug logs

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -542,10 +542,10 @@ void DownloadManager::onDownloadProgress(DownloadTask *task, qint64 bytesReceive
 
 void DownloadManager::processNextTask()
 {
-    LOG_DEBUG("处理下一个任务");
+    LOG_INFO("处理下一个任务");
     
     if (m_activeDownloadCount >= m_maxConcurrentDownloads) {
-        LOG_DEBUG("已达到最大并发数，跳过处理");
+        LOG_INFO("已达到最大并发数，跳过处理");
         return;
     }
     

--- a/src/downloadtask.cpp
+++ b/src/downloadtask.cpp
@@ -14,7 +14,7 @@ DownloadTask::DownloadTask(QObject *parent)
     , m_speed(0)
     , m_supportsResume(false)
 {
-    LOG_DEBUG("创建新的下载任务");
+    LOG_INFO("创建新的下载任务");
     generateId();
 }
 
@@ -27,7 +27,7 @@ DownloadTask::DownloadTask(const QString &url, const QString &savePath, QObject 
 
 DownloadTask::~DownloadTask()
 {
-    LOG_DEBUG(QString("销毁下载任务 - ID: %1").arg(m_id));
+    LOG_INFO(QString("销毁下载任务 - ID: %1").arg(m_id));
 }
 
 void DownloadTask::setUrl(const QString &url)

--- a/src/smbdirmodelworker.cpp
+++ b/src/smbdirmodelworker.cpp
@@ -1,5 +1,6 @@
 #include "smbdirmodelworker.h"
 #include <QFileSystemModel>
+#include "logger.h"
 
 SmbDirModelWorker::SmbDirModelWorker(QObject *parent)
     : QObject(parent)
@@ -8,7 +9,9 @@ SmbDirModelWorker::SmbDirModelWorker(QObject *parent)
 
 void SmbDirModelWorker::load(const QString &rootPath)
 {
+    LOG_INFO(QString("加载目录模型: %1").arg(rootPath));
     QFileSystemModel *model = new QFileSystemModel;
     model->setRootPath(rootPath);
     emit loaded(model, rootPath);
+    LOG_INFO(QString("目录模型加载完成: %1").arg(rootPath));
 }

--- a/src/smbdownloader.cpp
+++ b/src/smbdownloader.cpp
@@ -243,6 +243,9 @@ void SmbDownloader::updateSpeed()
                 info->lastSpeedUpdate = currentTime;
                 info->lastBytesReceived = task->downloadedSize();
                 task->setSpeed(static_cast<qint64>(info->smoothedSpeed));
+                LOG_INFO(QString("任务 %1 当前速度: %2 B/s")
+                             .arg(task->id())
+                             .arg(task->speed()));
             }
         }
     }

--- a/src/smbpathchecker.cpp
+++ b/src/smbpathchecker.cpp
@@ -1,6 +1,7 @@
 #include "smbpathchecker.h"
 #include <QDir>
 #include <QUrl>
+#include "logger.h"
 
 static QString toUncPath(QString path)
 {
@@ -26,8 +27,10 @@ SmbPathChecker::SmbPathChecker(QObject *parent)
 
 void SmbPathChecker::check(const QString &path)
 {
+    LOG_INFO(QString("检查远程路径: %1").arg(path));
     QString uncPath = toUncPath(path);
     bool ok = QDir(uncPath).exists();
+    LOG_INFO(QString("路径 %1 %2").arg(uncPath).arg(ok ? "存在" : "不存在"));
     emit finished(ok, uncPath);
 }
 

--- a/src/tasktablewidget.cpp
+++ b/src/tasktablewidget.cpp
@@ -3,10 +3,12 @@
 #include <QProgressBar>
 #include <QHBoxLayout>
 #include <QPushButton>
+#include "logger.h"
 
 TaskTableWidget::TaskTableWidget(QWidget *parent)
     : QTableWidget(parent)
 {
+    LOG_INFO("初始化 TaskTableWidget");
     setupTable();
 }
 
@@ -39,6 +41,7 @@ void TaskTableWidget::setupTable()
 
 void TaskTableWidget::addTask(DownloadTask *task)
 {
+    LOG_INFO(QString("向表格添加任务: %1").arg(task->id()));
     int row = rowCount();
     insertRow(row);
 
@@ -64,8 +67,10 @@ void TaskTableWidget::addTask(DownloadTask *task)
 void TaskTableWidget::removeTask(DownloadTask *task)
 {
     int row = findTaskRow(task);
-    if (row >= 0)
+    if (row >= 0) {
         removeRow(row);
+        LOG_INFO(QString("已从表格移除任务: %1").arg(task->id()));
+    }
 }
 
 int TaskTableWidget::findTaskRow(DownloadTask *task)
@@ -83,6 +88,7 @@ int TaskTableWidget::findTaskRow(DownloadTask *task)
 
 void TaskTableWidget::updateTask(DownloadTask *task)
 {
+    LOG_INFO(QString("更新任务行: %1").arg(task->id()));
     int row = findTaskRow(task);
     if (row < 0)
         return;
@@ -108,6 +114,7 @@ void TaskTableWidget::updateTask(DownloadTask *task)
 
 void TaskTableWidget::createOperationButtons(int row, DownloadTask *task)
 {
+    LOG_INFO(QString("创建操作按钮 - 任务ID: %1").arg(task->id()));
     QWidget *widget = new QWidget();
     QHBoxLayout *layout = new QHBoxLayout(widget);
     layout->setContentsMargins(2,2,2,2);
@@ -136,6 +143,8 @@ void TaskTableWidget::updateOperationButtons(int row, DownloadTask *task)
 {
     QWidget *widget = cellWidget(row, 5);
     if (!widget) return;
+
+    LOG_INFO(QString("更新操作按钮显示 - 任务ID: %1").arg(task->id()));
 
     QList<QPushButton*> buttons = widget->findChildren<QPushButton*>();
     if (buttons.size() < 4) return;


### PR DESCRIPTION
## Summary
- switch all LOG_DEBUG uses to LOG_INFO so logs only use info level
- keep logging for directory scanning, task table updates, download manager, etc.

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be7e85094833190f2b5681b2f2a1c