### PR TITLE
Enable multi-selection in SMB browser

### DIFF
--- a/src/filebrowserdialog.cpp
+++ b/src/filebrowserdialog.cpp
@@ -7,6 +7,7 @@
 #include <QTimer>
 #include <QMessageBox>
 #include <QApplication>
+#include <QAbstractItemView>
 
 FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
     : QDialog(parent)
@@ -20,6 +21,7 @@ FileBrowserDialog::FileBrowserDialog(const QString &rootPath, QWidget *parent)
 
     m_model->setRootPath(rootPath);
     m_view->setModel(m_model);
+    m_view->setSelectionMode(QAbstractItemView::ExtendedSelection);
     QModelIndex rootIndex = m_model->index(rootPath);
     if (rootIndex.isValid()) {
         m_view->setRootIndex(rootIndex);


### PR DESCRIPTION
## Summary
- allow FileBrowserDialog to select more than one item

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bea3b65348331bbdaafd4e14c53ec