### PR TITLE
Remove concurrency limit

### DIFF
--- a/src/downloadmanager.h
+++ b/src/downloadmanager.h
@@ -47,8 +47,6 @@ public:
     // 设置
     QString getDefaultSavePath() const;
     void setDefaultSavePath(const QString &path);
-    int getMaxConcurrentDownloads() const;
-    void setMaxConcurrentDownloads(int max);
 
     // 最近一次输入的地址
     QString getLastUrl() const;
@@ -88,9 +86,8 @@ private slots:
 private:
     QMap<QString, DownloadTask*> m_tasks;
     SmbDownloader *m_smbDownloader;
-    
+
     QString m_defaultSavePath;
-    int m_maxConcurrentDownloads;
     int m_activeDownloadCount;
     QString m_lastUrl;
     

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -67,9 +67,6 @@ MainWindow::MainWindow(QWidget *parent)
     
     // 设置默认保存路径
     ui->savePathEdit->setText(m_downloadManager->getDefaultSavePath());
-    ui->concurrencySpinBox->setValue(m_downloadManager->getMaxConcurrentDownloads());
-    connect(ui->concurrencySpinBox, QOverload<int>::of(&QSpinBox::valueChanged),
-            m_downloadManager, &DownloadManager::setMaxConcurrentDownloads);
     
     // 启动更新定时器
     m_updateTimer->setInterval(1000); // 每秒更新一次

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -88,26 +88,6 @@
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_concurrency">
-             <property name="text">
-              <string>并发线程数：</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QSpinBox" name="concurrencySpinBox">
-             <property name="minimum">
-              <number>3</number>
-             </property>
-             <property name="maximum">
-              <number>8</number>
-             </property>
-             <property name="value">
-              <number>5</number>
-             </property>
-            </widget>
-           </item>
           </layout>
          </widget>
         </item>


### PR DESCRIPTION
## Summary
- drop maxConcurrentDownloads setting and related UI
- stop persisting maxConcurrentDownloads in config
- always start tasks immediately with no queue logic

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bec2ce5948331819d3698c2e1a9d9