### PR TITLE
Fix cancel persistence

### DIFF
--- a/src/downloadmanager.cpp
+++ b/src/downloadmanager.cpp
@@ -238,9 +238,11 @@ void DownloadManager::cancelTask(const QString &taskId)
     task->setErrorMessage(tr("用户取消"));
     
     LOG_INFO(QString("任务已取消 - ID: %1, 当前活跃下载数: %2").arg(taskId).arg(m_activeDownloadCount));
-    
+
     m_smbDownloader->cancelDownload(task);
-    
+
+    saveTasks();
+
     processNextTask();
 }
 


### PR DESCRIPTION
## Summary
- call `saveTasks()` in `DownloadManager::cancelTask` after cancelling via `SmbDownloader`

## Testing
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf601886c83318995be358795b6f7