### PR TITLE
Refactor path conversion helper

### DIFF
--- a/DownloadAssistant.pro
+++ b/DownloadAssistant.pro
@@ -26,7 +26,8 @@ SOURCES += \
     src/logger.cpp \
     src/tasktablewidget.cpp \
     src/filebrowserdialog.cpp \
-    src/smbpathchecker.cpp
+    src/smbpathchecker.cpp \
+    src/pathutils.cpp
 
 HEADERS += \
     src/mainwindow.h \
@@ -38,7 +39,8 @@ HEADERS += \
     src/tasktablewidget.h \
     src/filebrowserdialog.h \
     src/directoryworker.h \
-    src/smbpathchecker.h
+    src/smbpathchecker.h \
+    src/pathutils.h
 
 FORMS += \
     src/mainwindow.ui

--- a/src/directoryworker.cpp
+++ b/src/directoryworker.cpp
@@ -4,23 +4,7 @@
 #include <QFileInfo>
 #include <QUrl>
 #include "logger.h"
-
-static QString toUncPath(QString path)
-{
-    path.remove('\r');
-    path.remove('\n');
-    path = path.trimmed();
-    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
-        QUrl u(path);
-        QString p = u.path();
-        if (p.startsWith('/'))
-            p.remove(0, 1);
-        p.replace('/', '\\');
-        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
-    }
-    path.replace('/', '\\');
-    return path;
-}
+#include "pathutils.h"
 
 DirectoryWorker::DirectoryWorker(const QString &dirUrl, const QString &localPath,
                                  DownloadManager *manager, QObject *parent)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -16,6 +16,7 @@
 #include "tasktablewidget.h"
 #include "filebrowserdialog.h"
 #include "directoryworker.h"
+#include "pathutils.h"
 #include <QPushButton>
 #include <QTableWidgetItem>
 #include <QHeaderView>
@@ -27,22 +28,6 @@
 #include <QDesktopServices>
 #include <QSpinBox>
 
-static QString toUncPath(QString path)
-{
-    path.remove('\r');
-    path.remove('\n');
-    path = path.trimmed();
-    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
-        QUrl u(path);
-        QString p = u.path();
-        if (p.startsWith('/'))
-            p.remove(0, 1);
-        p.replace('/', '\\');
-        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
-    }
-    path.replace('/', '\\');
-    return path;
-}
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent)

--- a/src/pathutils.cpp
+++ b/src/pathutils.cpp
@@ -1,0 +1,19 @@
+#include "pathutils.h"
+#include <QUrl>
+
+QString toUncPath(QString path)
+{
+    path.remove('\r');
+    path.remove('\n');
+    path = path.trimmed();
+    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
+        QUrl u(path);
+        QString p = u.path();
+        if (p.startsWith('/'))
+            p.remove(0, 1);
+        p.replace('/', '\\');
+        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
+    }
+    path.replace('/', '\\');
+    return path;
+}

--- a/src/pathutils.h
+++ b/src/pathutils.h
@@ -1,0 +1,8 @@
+#ifndef PATHUTILS_H
+#define PATHUTILS_H
+
+#include <QString>
+
+QString toUncPath(QString path);
+
+#endif // PATHUTILS_H

--- a/src/smbpathchecker.cpp
+++ b/src/smbpathchecker.cpp
@@ -1,23 +1,7 @@
 #include "smbpathchecker.h"
 #include <QDir>
 #include <QUrl>
-
-static QString toUncPath(QString path)
-{
-    path.remove('\r');
-    path.remove('\n');
-    path = path.trimmed();
-    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
-        QUrl u(path);
-        QString p = u.path();
-        if (p.startsWith('/'))
-            p.remove(0, 1);
-        p.replace('/', '\\');
-        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
-    }
-    path.replace('/', '\\');
-    return path;
-}
+#include "pathutils.h"
 
 SmbPathChecker::SmbPathChecker(QObject *parent)
     : QObject(parent)

--- a/src/smbworker.cpp
+++ b/src/smbworker.cpp
@@ -7,23 +7,7 @@
 #include <QThread>
 #include <QDebug>
 #include "logger.h"
-
-static QString toUncPath(QString path)
-{
-    path.remove('\r');
-    path.remove('\n');
-    path = path.trimmed();
-    if (path.startsWith("smb://", Qt::CaseInsensitive)) {
-        QUrl u(path);
-        QString p = u.path();
-        if (p.startsWith('/'))
-            p.remove(0, 1);
-        p.replace('/', '\\');
-        return QStringLiteral("\\\\") + u.host() + QLatin1Char('\\') + p;
-    }
-    path.replace('/', '\\');
-    return path;
-}
+#include "pathutils.h"
 
 SmbWorker::SmbWorker(DownloadTask *task, QObject *parent)
     : QThread(parent), m_task(task), m_pauseRequested(false),


### PR DESCRIPTION
## Summary
- centralize `toUncPath` in new `pathutils` module
- include `pathutils` where needed and remove duplicate implementations
- update project file with new source/header

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_685bf5e9552483318c3585d156d53520