### PR TITLE
Update size display for tasks

### DIFF
--- a/src/tasktablewidget.cpp
+++ b/src/tasktablewidget.cpp
@@ -59,7 +59,7 @@ void TaskTableWidget::addTask(DownloadTask *task)
     setCellWidget(row, 1, progressBar);
 
     setItem(row, 2, new QTableWidgetItem(task->speedText()));
-    setItem(row, 3, new QTableWidgetItem(formatBytes(task->downloadedSize())));
+    setItem(row, 3, new QTableWidgetItem(formatBytes(task->fileSize())));
     setItem(row, 4, new QTableWidgetItem(task->timeRemainingText()));
 
     createOperationButtons(row, task);
@@ -102,10 +102,7 @@ void TaskTableWidget::updateTask(DownloadTask *task)
 
     item(row,2)->setText(task->speedText());
 
-    QString sizeText = formatBytes(task->downloadedSize());
-    if (task->fileSize() > 0)
-        sizeText += " / " + formatBytes(task->fileSize());
-    item(row,3)->setText(sizeText);
+    item(row,3)->setText(formatBytes(task->fileSize()));
 
     item(row,4)->setText(task->timeRemainingText());
 


### PR DESCRIPTION
## Summary
- show each task's total file size in the table instead of the downloaded amount

## Testing
- `qmake --version` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6863841c647c8331885cf8c1e6b85b42