### PR TITLE
Add concurrent chunked SMB downloads

### DIFF
--- a/src/smbworker.h
+++ b/src/smbworker.h
@@ -3,6 +3,8 @@
 
 #include <QThread>
 #include <QString>
+#include <QFile>
+#include <QMutex>
 
 class DownloadTask;
 
@@ -10,7 +12,9 @@ class SmbWorker : public QThread
 {
     Q_OBJECT
 public:
-    explicit SmbWorker(DownloadTask *task, QObject *parent = nullptr);
+    explicit SmbWorker(DownloadTask *task, QFile *file, QMutex *mutex,
+                       qint64 startOffset, qint64 chunkSize,
+                       QObject *parent = nullptr);
 
     void requestPause();
     void requestCancel();
@@ -25,9 +29,13 @@ protected:
 
 private:
     DownloadTask *m_task;
+    QFile *m_file;
+    QMutex *m_mutex;
     bool m_pauseRequested;
     bool m_cancelRequested;
-    qint64 m_offset;
-};
+    qint64 m_startOffset;
+    qint64 m_chunkSize;
+    qint64 m_bytesReceived;
+}; 
 
 #endif // SMBWORKER_H


### PR DESCRIPTION
## Summary
- update `SmbWorker` to support offset & chunk size and write to a shared file
- split downloads into multiple workers in `SmbDownloader`
- aggregate worker progress and update pause/resume/cancel logic
- expose configurable chunk size on `SmbDownloader`

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639bb762508331a8744ac3da1979b9