### PR TITLE
Fix SMB downloader compilation

### DIFF
--- a/src/smbdownloader.cpp
+++ b/src/smbdownloader.cpp
@@ -1,6 +1,7 @@
 #include "smbdownloader.h"
 #include "downloadtask.h"
 #include "smbworker.h"
+#include "pathutils.h"
 #include <QFileInfo>
 #include <QDir>
 #include <QFile>

--- a/src/smbdownloader.h
+++ b/src/smbdownloader.h
@@ -19,8 +19,6 @@ public:
     explicit SmbDownloader(QObject *parent = nullptr);
     ~SmbDownloader();
 
-    void setChunkSize(qint64 size) { m_chunkSize = size; }
-    qint64 chunkSize() const { return m_chunkSize; }
 
     // 下载控制
     bool startDownload(DownloadTask *task);


### PR DESCRIPTION
## Summary
- include `pathutils.h` in `smbdownloader.cpp` so `toUncPath` resolves
- remove unused `setChunkSize` and `chunkSize` functions from `smbdownloader.h`

## Testing
- `qmake DownloadAssistant.pro` *(fails: qmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a0cb4bc883318f905c15bbafefed