### PR TITLE
Remove unused start time

### DIFF
--- a/src/downloadtask.h
+++ b/src/downloadtask.h
@@ -62,9 +62,6 @@ public:
     void setSupportsResume(bool supports) { m_supportsResume = supports; }
     
     // 时间信息
-    QDateTime startTime() const { return m_startTime; }
-    void setStartTime(const QDateTime &time) { m_startTime = time; }
-    
     QDateTime endTime() const { return m_endTime; }
     void setEndTime(const QDateTime &time) { m_endTime = time; }
     
@@ -94,7 +91,6 @@ private:
     qint64 m_speed;
     QString m_errorMessage;
     bool m_supportsResume;
-    QDateTime m_startTime;
     QDateTime m_endTime;
 };
 


### PR DESCRIPTION
## Summary
- stop tracking task start times
- only keep end time in config
- clean up SMB downloader start logic

## Testing
- `qmake` *(fails: command not found)*
- `make` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_686c78ffbf7883318f925aaedee5bf01