### PR TITLE
Remove unused fetchSmbFileList

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -455,12 +455,6 @@ QString MainWindow::buildFinalSavePath(const QString &basePath) const
     return dateDirPath;
 }
 
-void MainWindow::fetchSmbFileList(const QString &url)
-{
-    // 这里原本有 remoteFileTable 的相关操作，已移除
-    // 你可以根据新 UI 逻辑实现文件选择后的处理
-}
-
 void MainWindow::onDownloadFileClicked(const QString &fileUrl)
 {
     LOG_INFO(QString("开始下载文件: %1").arg(fileUrl));

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -72,7 +72,6 @@ private:
     void showWarning(const QString &message);
     void showError(const QString &message);
     QString formatBytes(qint64 bytes) const;
-    void fetchSmbFileList(const QString &url);
 
     QString buildFinalSavePath(const QString &basePath) const;
 


### PR DESCRIPTION
## Summary
- remove leftover `fetchSmbFileList` declaration and empty definition

## Testing
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c837186008331bdcf51fb2094debf