### PR TITLE
Remove unused slot declaration

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -66,7 +66,6 @@ private:
     void updateStatusBar();
     void onStartAllClicked();
     void onPauseAllClicked();
-    void onRemoveClicked();
     void onAllTasksCompleted();
     void showInfo(const QString &message);
     void showWarning(const QString &message);


### PR DESCRIPTION
## Summary
- remove unused onRemoveClicked from MainWindow header

## Testing
- `qmake --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c83776efc8331ad7bed96e731e2ca